### PR TITLE
Cheerbot 7 setup api

### DIFF
--- a/commands/utility/cheerup.js
+++ b/commands/utility/cheerup.js
@@ -1,0 +1,31 @@
+import { SlashCommandBuilder } from "discord.js";
+import axios from "axios";
+
+const fetchQuotes = async () => {
+    try {
+        const response = await axios.get("https://zenquotes.io/api/quotes");
+        const quotes = response.data;
+
+        const randomQuote = quotes[Math.floor(Math.random() * quotes.length )];
+
+        return randomQuote;
+    } catch (error) {
+        console.error("Error fetching quote:", error);
+        return null;
+    };
+};
+
+export const command = {
+    data: new SlashCommandBuilder()
+        .setName("cheerup") // placeholder name - can be changed to something we both like
+        .setDescription("Replies with a positive quote to help you cheer up!"),
+        async execute(interaction) {
+            const quote = await fetchQuotes();
+
+            if (quote) {
+                await interaction.reply(`Here's a positive quote: "${quote.q}" - ${quote.a}`)
+            } else {
+                await interaction.reply("Sorry, I couldn't fetch a quote at the moment. 😣")
+            };
+        },
+};


### PR DESCRIPTION
- Created a slash command for users to interact with CheerBot for a random uplifting quote
- Currently using [Zen Quotes](https://zenquotes.io) for data (I also liked this [repo's](https://github.com/bmumz/inspirational-quotes-api) quotes... should we also incorporate this? Like make our own JSON with those quotes and add to it as needed?)
- Use` /cheerup` a few times in the bot-testing channel on our server to see different quotes
- We can rename the slash command if you want 😂 Is "cheerup" too direct/declarative? Maybe "cheermeup" but that's too long haha.
- Deleted config.json since we are using environment variables.

Trying it out:

![Screenshot 2024-11-26 at 2 42 46 PM](https://github.com/user-attachments/assets/1b5e10cf-e773-47ac-8540-7e967b7ff67d)
